### PR TITLE
Show current file in UI notifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12)
 
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-project(mediacopier VERSION 2.0.4)
+project(mediacopier VERSION 2.0.5)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Previously, the UI notifications showed the last successful file operation, which was confusing when seemingly the copying of a simple jpeg file would take much time while we were actually working on copying a heavy mp4 or so.